### PR TITLE
Added Alfred 3 Theme

### DIFF
--- a/Alfred 2/Dracula.alfredappearance
+++ b/Alfred 2/Dracula.alfredappearance
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+# Dracula Theme v1.2.5
+# https://github.com/zenorocha/dracula-theme#
+# Copyright 2016, All rights reserved
+#
+# Code licensed under the MIT license
+# http://zenorocha.mit-license.org
+#
+# @author Oswaldo Acauan <oswaldoacauan@gmail.com>
+# @author Zeno Rocha <hi@zenorocha.com>
+-->
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>background</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg6GgID6DqagoPoPa2Fg+AYY=
+		</data>
+		<key>border</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg/r4eD+D+vh4P4P08nI/g5qZmT6G
+		</data>
+		<key>cornerRoundness</key>
+		<integer>0</integer>
+		<key>credits</key>
+		<string>@oswaldoacauan</string>
+		<key>imageStyle</key>
+		<integer>5</integer>
+		<key>name</key>
+		<string>Dracula</string>
+		<key>resultPaddingSize</key>
+		<integer>0</integer>
+		<key>resultSelectedBackgroundColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg4mIiD6Dj46OPoO1tLQ+AYY=
+		</data>
+		<key>resultSelectedSubtextColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg769PT+DlJMTP4P7+Xk/AYY=
+		</data>
+		<key>resultSelectedTextColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg/r4eD+D+vh4P4P08nI/AYY=
+		</data>
+		<key>resultSubtextColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg8bExD6D5uTkPoOlpCQ/AYY=
+		</data>
+		<key>resultSubtextFont</key>
+		<string>Helvetica</string>
+		<key>resultSubtextFontSize</key>
+		<integer>1</integer>
+		<key>resultTextColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg/r4eD+D+vh4P4P08nI/gwAAAD+G
+		</data>
+		<key>resultTextFont</key>
+		<string>Helvetica</string>
+		<key>resultTextFontSize</key>
+		<integer>2</integer>
+		<key>scrollbarColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmAYP08vI+g8jGRj8Bhg==
+		</data>
+		<key>searchBackgroundColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg6GgID6DqagoPoPa2Fg+AYY=
+		</data>
+		<key>searchFont</key>
+		<string>Helvetica</string>
+		<key>searchFontSize</key>
+		<integer>4</integer>
+		<key>searchForegroundColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg/r4eD+D+vh4P4P08nI/AYY=
+		</data>
+		<key>searchPaddingSize</key>
+		<integer>3</integer>
+		<key>searchSelectionBackgroundColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMGhANA
+			QECEhIQITlNTdHJpbmcBlIQBKwZTeXN0ZW2GhJaYG3NlbGVjdGVkVGV4dEJhY2tncm91
+			bmRDb2xvcoaEk5UDhAJmZoOrqio/AYaG
+		</data>
+		<key>searchSelectionForegroundColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMDhAJm
+			ZgABhg==
+		</data>
+		<key>separatorColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg6GgID6DqagoPoPa2Fg+AYY=
+		</data>
+		<key>shortcutColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg4yLCz+D6+lpP4P//X0/AYY=
+		</data>
+		<key>shortcutFont</key>
+		<string>Helvetica</string>
+		<key>shortcutFontSize</key>
+		<integer>2</integer>
+		<key>shortcutSelectedColor</key>
+		<data>
+			BAtzdHJlYW10eXBlZIHoA4QBQISEhAdOU0NvbG9yAISECE5TT2JqZWN0AIWEAWMChARm
+			ZmZmg6GgoD6D/Pp6P4P49vY+AYY=
+		</data>
+		<key>uid</key>
+		<string>alfred.theme.custom.08BFF80E-8B87-43D9-A4C2-2F6831C50E0D</string>
+		<key>widthSize</key>
+		<integer>3</integer>
+	</dict>
+</plist>

--- a/Alfred 3/Dracula.alfredappearance
+++ b/Alfred 3/Dracula.alfredappearance
@@ -1,0 +1,61 @@
+{
+  "alfredtheme" : {
+    "result" : {
+      "textSpacing" : 5,
+      "subtext" : {
+        "size" : 12,
+        "colorSelected" : "#BD93F9A8",
+        "font" : "System",
+        "color" : "#6171A3BF"
+      },
+      "shortcut" : {
+        "size" : 16,
+        "colorSelected" : "#50FA7BFF",
+        "font" : "System",
+        "color" : "#8BE9FD4C"
+      },
+      "backgroundSelected" : "#444759E4",
+      "text" : {
+        "size" : 18,
+        "colorSelected" : "#F8F8F2FF",
+        "font" : "System",
+        "color" : "#F8F8F27F"
+      },
+      "iconPaddingHorizontal" : 4,
+      "paddingVertical" : 3,
+      "iconSize" : 40
+    },
+    "search" : {
+      "paddingVertical" : 5,
+      "background" : "#282A3600",
+      "spacing" : 4,
+      "text" : {
+        "size" : 34,
+        "colorSelected" : "#000000FF",
+        "font" : "System Thin",
+        "color" : "#F8F8F2FF"
+      },
+      "backgroundSelected" : "#A3CCFEFF"
+    },
+    "window" : {
+      "color" : "#282A36BF",
+      "paddingHorizontal" : 4,
+      "width" : 559,
+      "borderPadding" : 0,
+      "borderColor" : "#0000007F",
+      "blur" : 40,
+      "roundness" : 3,
+      "paddingVertical" : 4
+    },
+    "credit" : "Zeno Rocha",
+    "separator" : {
+      "color" : "#CBCBCBF3",
+      "thickness" : 0
+    },
+    "scrollbar" : {
+      "color" : "#FF79C6FF",
+      "thickness" : 2
+    },
+    "name" : "Dracula"
+  }
+}


### PR DESCRIPTION
I updated the Alfred Theme to match the current flat design of Alfred, this was made using Alfred 3. The color scheme is almost identical to the old theme, it's just more flat and matches the newer OS X UI style. 

![screen shot 2016-05-19 at 11 35 31 am](https://cloud.githubusercontent.com/assets/1607028/15399552/21e5aff6-1db6-11e6-9b3f-1722b905e07c.png)
